### PR TITLE
chore(github@actions): add `timeout-minutes`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   analyze:
+    timeout-minutes: 3
     name: Analyze
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes